### PR TITLE
chore: specify namespace in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ curl http://localhost:9187/metrics
 To access Grafana, run:
 
 ```bash
-kubectl -n <namespace> port-forward svc/grafana 3000:80
+kubectl -n coder-observability port-forward svc/grafana 3000:80
 ```
 
 And open your web browser to http://localhost:3000/.


### PR DESCRIPTION
this is just personal preference, but I think given we explicitly mention the namespace in the postgres metrics section (`kubectl -n coder-observability port-forward statefulset/postgres-exporter 9187`) we should mention it here.