### PR TITLE
feat: define alerts for replicas and build failures

### DIFF
--- a/coder-observability/runbooks/coderd.md
+++ b/coder-observability/runbooks/coderd.md
@@ -45,15 +45,19 @@ If Coder is not restarting due to excessive memory usage, check the logs:
 
 1. Check the logs of the deployment for any errors,
 
-  ```console
-  kubectl -n <coder namespace> logs deployment/coder --previous
-  ```
+```console
+kubectl -n <coder namespace> logs deployment/coder --previous
+```
 
 2. Check any Kubernetes events related to the deployment,
 
-  ```console
-  kubectl -n <coder namespace> events --watch
-  ```
+```console
+kubectl -n <coder namespace> events --watch
+```
+
+## CoderdReplicas
+
+TODO
 
 ## CoderdLicenseSeats
 

--- a/coder-observability/runbooks/coderd.md
+++ b/coder-observability/runbooks/coderd.md
@@ -59,6 +59,10 @@ kubectl -n <coder namespace> events --watch
 
 TODO
 
+## CoderdWorkspaceBuildFailures
+
+TODO
+
 ## CoderdLicenseSeats
 
 Your Enterprise license is approaching or has exceeded the number of seats purchased.

--- a/coder-observability/runbooks/provisionerd.md
+++ b/coder-observability/runbooks/provisionerd.md
@@ -1,0 +1,5 @@
+# Provisionerd Runbooks
+
+## ProvisionerdReplicas
+
+TODO

--- a/coder-observability/templates/configmap-prometheus-alerts.yaml
+++ b/coder-observability/templates/configmap-prometheus-alerts.yaml
@@ -10,7 +10,7 @@ data:
   coderd.yaml: |-
     groups:
   {{- with .groups.CPU }}
-  {{- $group := . }}
+  {{- $group := . }}  
   {{- if .enabled }}
     - name: CPU Usage
       rules:
@@ -65,6 +65,51 @@ data:
       {{- end }}
   {{- end }}
   {{- end }}
+
+  {{- with .groups.Replicas }}
+  {{- $group := . }}
+  {{- if .enabled }}
+    - name: Coderd Replicas
+      rules:
+      {{ $alert := "CoderdReplicas" }}
+      {{- range $severity, $threshold := .thresholds }}
+      - alert: {{ $alert }}
+        expr: sum(up{ {{- include "coderd-selector" $ -}} }) < {{ $threshold }}
+        for: {{ $group.delay }}
+        annotations:
+          summary: Number of alive coderd replicas is below the threshold = {{ $threshold -}}.
+        labels:
+          severity: {{ $severity }}
+          runbook_url: {{ template "runbook-url" (deepCopy $ | merge (dict "alert" $alert) $service) }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+
+  {{- end }} {{/* end-section */}}
+
+
+  {{- with .Values.global.coder.alerts.provisionerd }} {{/* start-section */}}
+  provisionerd.yaml: |-
+    groups:
+  {{- with .groups.Replicas }}
+  {{- $group := . }}
+  {{- if .enabled }}
+    - name: Coderd Replicas
+      rules:
+      {{ $alert := "ProvisionerdReplicas" }}
+      {{- range $severity, $threshold := .thresholds }}
+      - alert: {{ $alert }}
+        expr: sum(coderd_provisionerd_num_daemons) < {{ $threshold }}
+        for: {{ $group.delay }}
+        annotations:
+          summary: Number of alive provisionerd replicas is below the threshold = {{ $threshold -}}.
+        labels:
+          severity: {{ $severity }}
+          runbook_url: {{ template "runbook-url" (deepCopy $ | merge (dict "alert" $alert) $service) }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+
   {{- end }} {{/* end-section */}}
 
 

--- a/coder-observability/templates/configmap-prometheus-alerts.yaml
+++ b/coder-observability/templates/configmap-prometheus-alerts.yaml
@@ -85,6 +85,25 @@ data:
   {{- end }}
   {{- end }}
 
+  {{- with .groups.WorkspaceBuildFailures }}
+  {{- $group := . }}
+  {{- if .enabled }}
+    - name: Coderd Workspace Build Failures
+      rules:
+      {{ $alert := "CoderdWorkspaceBuildFailures" }}
+      {{- range $severity, $threshold := .thresholds }}
+      - alert: {{ $alert }}
+        expr: sum(increase(coderd_workspace_builds_total{ {{- include "coderd-selector" $ -}} , status="failed" }[{{- $group.period -}}])) > {{ $threshold }}
+        for: {{ $group.delay }}
+        annotations:
+          summary: Workspace builds have failed multiple times in the last {{ $group.period -}}, which may indicate a broken Coder template.
+        labels:
+          severity: {{ $severity }}
+          runbook_url: {{ template "runbook-url" (deepCopy $ | merge (dict "alert" $alert) $service) }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+
   {{- end }} {{/* end-section */}}
 
 
@@ -94,12 +113,12 @@ data:
   {{- with .groups.Replicas }}
   {{- $group := . }}
   {{- if .enabled }}
-    - name: Coderd Replicas
+    - name: Provisionerd Replicas
       rules:
       {{ $alert := "ProvisionerdReplicas" }}
       {{- range $severity, $threshold := .thresholds }}
       - alert: {{ $alert }}
-        expr: sum(coderd_provisionerd_num_daemons) < {{ $threshold }}
+        expr: sum(coderd_provisionerd_num_daemons{ {{- include "coderd-selector" $ -}} }) < {{ $threshold }}
         for: {{ $group.delay }}
         annotations:
           summary: Number of alive provisionerd replicas is below the threshold = {{ $threshold -}}.

--- a/coder-observability/values.yaml
+++ b/coder-observability/values.yaml
@@ -63,6 +63,28 @@ global:
               notify: 1
               warning: 2
               critical: 3
+          Replicas:
+            enabled: true
+            delay: 1m
+            thresholds:
+              warning: 0.67 # 2/3 replicas healthy
+              critical: 0.34 # 1/3 replicas healthy
+          Builds:
+            enabled: true
+            delay: 1m
+            period: 10m
+            thresholds:
+              notify: 1
+              warning: 2
+              critical: 3
+      provisioner:
+        groups:
+          Instances:
+            enabled: true
+            delay: 1m
+            thresholds:
+              warning: 0.67 # 2/3 replicas healthy
+              critical: 0.34 # 1/3 replicas healthy
 
   zone: svc
 

--- a/coder-observability/values.yaml
+++ b/coder-observability/values.yaml
@@ -65,26 +65,29 @@ global:
               critical: 3
           Replicas:
             enabled: true
-            delay: 1m
+            delay: 5m
             thresholds:
-              warning: 0.67 # 2/3 replicas healthy
-              critical: 0.34 # 1/3 replicas healthy
-          Builds:
-            enabled: true
-            delay: 1m
-            period: 10m
-            thresholds:
-              notify: 1
-              warning: 2
-              critical: 3
-      provisioner:
+              notify: 3 # 2/3 replicas are alive
+              warning: 2 # 1/3 replicas are alive
+              critical: 1 # 0/3 replicas are alive
+          WorkspaceBuilds:
+            Failures:
+              enabled: true
+              delay: 5m
+              period: 10m
+              thresholds:
+                notify: 1
+                warning: 2
+                critical: 3
+      provisionerd:
         groups:
-          Instances:
+          Replicas:
             enabled: true
-            delay: 1m
+            delay: 5m
             thresholds:
-              warning: 0.67 # 2/3 replicas healthy
-              critical: 0.34 # 1/3 replicas healthy
+              notify: 3 # 2/3 replicas are alive
+              warning: 2 # 1/3 replicas are alive
+              critical: 1 # 0/3 replicas are alive
 
   zone: svc
 

--- a/coder-observability/values.yaml
+++ b/coder-observability/values.yaml
@@ -70,15 +70,14 @@ global:
               notify: 3 # 2/3 replicas are alive
               warning: 2 # 1/3 replicas are alive
               critical: 1 # 0/3 replicas are alive
-          WorkspaceBuilds:
-            Failures:
-              enabled: true
-              delay: 5m
-              period: 10m
-              thresholds:
-                notify: 1
-                warning: 2
-                critical: 3
+          WorkspaceBuildFailures:
+            enabled: true
+            delay: 10m
+            period: 10m
+            thresholds:
+              notify: 2
+              warning: 5
+              critical: 10
       provisionerd:
         groups:
           Replicas:


### PR DESCRIPTION
Fixes: https://github.com/coder/observability/issues/15

This PR adds few Prometheus alert definitions to coder-observability bundle.

<img width="1045" alt="Screenshot 2024-06-13 at 14 02 24" src="https://github.com/coder/observability/assets/14044910/ca1612c3-7d4e-4435-8c28-bbd265e52b9f">
