### PR TITLE
fix: default rule files

### DIFF
--- a/coder-observability/values.yaml
+++ b/coder-observability/values.yaml
@@ -425,8 +425,9 @@ prometheus:
       scrape_configs:
       # use custom rule files to be able to render templates (can't do that in values.yaml, unless that value is evaluated by a tpl call)
       rule_files:
+        - /etc/config/alerts/coderd.yaml
+        - /etc/config/alerts/enterprise.yaml
         - /etc/config/alerts/postgres.yaml
-        - /etc/config/alerts/coder.yaml
 
   testFramework:
     enabled: false

--- a/coder-observability/values.yaml
+++ b/coder-observability/values.yaml
@@ -425,9 +425,7 @@ prometheus:
       scrape_configs:
       # use custom rule files to be able to render templates (can't do that in values.yaml, unless that value is evaluated by a tpl call)
       rule_files:
-        - /etc/config/alerts/coderd.yaml
-        - /etc/config/alerts/enterprise.yaml
-        - /etc/config/alerts/postgres.yaml
+        - /etc/config/alerts/*.yaml
 
   testFramework:
     enabled: false


### PR DESCRIPTION
Related: https://github.com/coder/observability/issues/15

This PR corrects `rule_files` to point to real resources imported from the config map.