### PR TITLE
v0.2.1 bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.2.1
+
+- Upgraded subcharts
+  - Loki: upgraded to v6.7.1 -> v6.7.3
+- FIX: `listen-address` duplicate removed in `prometheus-config-reloader`
+
 ## v0.2.0
 
 - Upgraded subcharts

--- a/README.md
+++ b/README.md
@@ -433,7 +433,6 @@ values which are defined [here](https://github.com/grafana/helm-charts/tree/main
 | prometheus.alertmanager.podAnnotations."prometheus.io/scrape" | string | `"true"` |  |
 | prometheus.alertmanager.service.port | int | `80` |  |
 | prometheus.configmapReload.prometheus.containerPort | int | `9091` |  |
-| prometheus.configmapReload.prometheus.extraArgs.listen-address | string | `"0.0.0.0:9091"` |  |
 | prometheus.configmapReload.prometheus.extraArgs.log-level | string | `"all"` |  |
 | prometheus.configmapReload.prometheus.extraArgs.watch-interval | string | `"15s"` |  |
 | prometheus.configmapReload.prometheus.extraConfigmapMounts[0].configMap | string | `"metrics-alerts"` |  |

--- a/coder-observability/Chart.lock
+++ b/coder-observability/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 25.24.1
 - name: loki
   repository: https://grafana.github.io/helm-charts
-  version: 6.7.1
+  version: 6.7.3
 - name: grafana-agent
   repository: https://grafana.github.io/helm-charts
   version: 0.37.0
-digest: sha256:281e36cc647d94dbf3d61e6cf237c2cee6c1a4a3a663b56bd1acba6a35cdb921
-generated: "2024-07-22T11:48:40.953894+02:00"
+digest: sha256:10a5d2b617b691e0ed87ca9e31c86618e05ca3b8031ddb3b417610f47e8bb069
+generated: "2024-07-26T10:52:20.819468+02:00"

--- a/coder-observability/values.yaml
+++ b/coder-observability/values.yaml
@@ -457,7 +457,6 @@ prometheus:
     prometheus:
       extraArgs:
         log-level: all
-        listen-address: 0.0.0.0:9091
         watch-interval: 15s
       containerPort: 9091
       extraConfigmapMounts:

--- a/compiled/resources.yaml
+++ b/compiled/resources.yaml
@@ -10162,7 +10162,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff23ab7fb28317d44f32989811420210d0dafee54196d89ab5335e95846350ad
+        checksum/config: 308677931777ae343a565387f5edecd66c53876ef7d120e9df3c6196c1884b30
       labels:
         app.kubernetes.io/name: loki
         app.kubernetes.io/instance: coder-observability
@@ -10246,7 +10246,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 140751cc58d257d5572ecb927b0fbe6d86da84e12809df37a9dc5bbdb6902202
+        checksum/config: 616b4c9b39f90d71edfd156f86c7f57751f662542a83f3e345c30496c3da7d27
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/part-of: memberlist
@@ -10725,7 +10725,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 140751cc58d257d5572ecb927b0fbe6d86da84e12809df37a9dc5bbdb6902202
+        checksum/config: 616b4c9b39f90d71edfd156f86c7f57751f662542a83f3e345c30496c3da7d27
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: loki
@@ -11042,7 +11042,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 140751cc58d257d5572ecb927b0fbe6d86da84e12809df37a9dc5bbdb6902202
+        checksum/config: 616b4c9b39f90d71edfd156f86c7f57751f662542a83f3e345c30496c3da7d27
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: loki

--- a/compiled/resources.yaml
+++ b/compiled/resources.yaml
@@ -11255,7 +11255,6 @@ spec:
             - --watched-dir=/etc/config
             - --listen-address=0.0.0.0:9091
             - --reload-url=http://127.0.0.1:9090/-/reload
-            - --listen-address=0.0.0.0:9091
             - --log-level=all
             - --watch-interval=15s
           ports:


### PR DESCRIPTION
- `listen-address` was duplicated in `prometheus-config-reloader` because the Promtheus chart now adds the CLI flag automatically
  - this led to the `prometheus-config-reloader` crashing with the error `flag 'listen-address' cannot be repeated`
- Drive-by Loki upgrade