### PR TITLE
Add Ingress config to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,22 @@ stringData:
   password: "<your password>" # this matches the "passwordKey" field above
 ```
 
+To add an Ingress for Grafana, define this in your `values.yaml`:
+
+```yaml
+grafana:
+  grafana.ini:
+    server:
+      domain: observability.example.com
+      root_url: "%(protocol)s://%(domain)s/grafana"
+      serve_from_sub_path: true
+  ingress:
+    enabled: true
+    hosts:
+      - "observability.example.com"
+    path: "/"
+```
+
 ## Subcharts
 
 | Repository | Name | Version |


### PR DESCRIPTION
This adds an ingress config example for the grafana dashboard.  I tested this in our RKE2 cluster, the only additional steps were adding a DNS entry in Route53 pointing to our load balancer, and adding a cert to the TLS listener.  The example instructions come from https://github.com/grafana/helm-charts/blob/main/charts/grafana/README.md#example-ingress-with-path