### PR TITLE
fix: version.sh preserve `v` prefix and correctly bump integer on major bump

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -25,7 +25,7 @@ function bump_version() {
   local new_version
 
   if [[ $version == "major" ]]; then
-    new_version=$(echo $current_version | awk -F. '{print $1+1".0.0"}')
+    new_version=$(echo $current_version | sed 's/^v//' | awk -F. '{print "v" $1+1".0.0"}')
   elif [[ $version == "minor" ]]; then
     new_version=$(echo $current_version | awk -F. '{print $1"."$2+1".0"}')
   elif [[ $version == "patch" ]]; then


### PR DESCRIPTION
Take a look: https://onlinegdb.com/GBEi-HK_K

The `minor` and `patch` bumps are ok, as they take the first argument as is. The major bump does `$1 + 1`. The first argument is `v#`, which is a string. And `awk` treats `string + 1 = 1`. 

So this only affects the major bump.