### PR TITLE
chore: clustering mode is required for pyroscope 

### DIFF
--- a/coder-observability/templates/_collector-config.tpl
+++ b/coder-observability/templates/_collector-config.tpl
@@ -210,6 +210,10 @@ pyroscope.scrape "pods" {
 
   scrape_interval = "{{ .Values.global.telemetry.profiling.scrape_interval }}"
   scrape_timeout = "{{ .Values.global.telemetry.profiling.scrape_timeout }}"
+
+  clustering {
+    enabled = true
+  }
 }
 
 pyroscope.write "pods" {

--- a/coder-observability/values.yaml
+++ b/coder-observability/values.yaml
@@ -186,7 +186,7 @@ grafana-agent:
       key: config.river
       create: false
     clustering:
-      enabled: false
+      enabled: true
     extraArgs:
       - --disable-reporting=true
     mounts:


### PR DESCRIPTION
Profiling cannot occur by 2 agents at the same time. Clustering distributed these jobs evenly across agents. 

This is to solve this error in production on agents:

```
server returned HTTP status (500) Could not enable CPU profiling: cpu profiling already in use
```