### PR TITLE
fix: rename nativeHistograms flag to native_histograms

### DIFF
--- a/README.gotmpl
+++ b/README.gotmpl
@@ -239,7 +239,7 @@ To enable native histograms, define this in your `values.yaml`:
 global:
   telemetry:
     metrics:
-      nativeHistograms: true
+      native_histograms: true
 
 prometheus:
   server:

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ To enable native histograms, define this in your `values.yaml`:
 global:
   telemetry:
     metrics:
-      nativeHistograms: true
+      native_histograms: true
 
 prometheus:
   server:
@@ -328,9 +328,9 @@ values which are defined [here](https://github.com/grafana/helm-charts/tree/main
 | global.externalZone | string | `"svc.cluster.local"` |  |
 | global.postgres | object | `{"alerts":{"groups":{"Basic":{"delay":"1m","enabled":true},"Connections":{"delay":"5m","enabled":true,"thresholds":{"critical":0.9,"notify":0.5,"warning":0.8}},"Notifications":{"delay":"15m","enabled":true,"thresholds":{"critical":0.9,"notify":0.5,"warning":0.8}}}},"database":"coder","exporter":{"image":"quay.io/prometheuscommunity/postgres-exporter"},"hostname":"localhost","mountSecret":"secret-postgres","password":null,"port":5432,"sslmode":"disable","sslrootcert":null,"username":"coder","volumeMounts":[],"volumes":[]}` | postgres connection information NOTE: these settings are global so we can parameterise some values which get rendered by subcharts |
 | global.postgres.alerts | object | `{"groups":{"Basic":{"delay":"1m","enabled":true},"Connections":{"delay":"5m","enabled":true,"thresholds":{"critical":0.9,"notify":0.5,"warning":0.8}},"Notifications":{"delay":"15m","enabled":true,"thresholds":{"critical":0.9,"notify":0.5,"warning":0.8}}}}` | alerts for postgres |
-| global.telemetry | object | `{"metrics":{"nativeHistograms":false,"scrape_interval":"15s","scrape_timeout":"12s"},"profiling":{"delta_profiling_duration":"30s","scrape_interval":"60s","scrape_timeout":"70s"}}` | control telemetry collection |
-| global.telemetry.metrics | object | `{"nativeHistograms":false,"scrape_interval":"15s","scrape_timeout":"12s"}` | control metric collection |
-| global.telemetry.metrics.nativeHistograms | bool | `false` | enable Prometheus native histograms or default to classic histograms |
+| global.telemetry | object | `{"metrics":{"native_histograms":false,"scrape_interval":"15s","scrape_timeout":"12s"},"profiling":{"delta_profiling_duration":"30s","scrape_interval":"60s","scrape_timeout":"70s"}}` | control telemetry collection |
+| global.telemetry.metrics | object | `{"native_histograms":false,"scrape_interval":"15s","scrape_timeout":"12s"}` | control metric collection |
+| global.telemetry.metrics.native_histograms | bool | `false` | enable Prometheus native histograms or default to classic histograms |
 | global.telemetry.metrics.scrape_interval | string | `"15s"` | how often the collector will scrape discovered pods |
 | global.telemetry.metrics.scrape_timeout | string | `"12s"` | how long a request will be allowed to wait before being canceled |
 | global.telemetry.profiling.delta_profiling_duration | string | `"30s"` | duration of each pprof profiling capture, must be less than scrape_interval |

--- a/coder-observability/templates/_collector-config.tpl
+++ b/coder-observability/templates/_collector-config.tpl
@@ -230,7 +230,7 @@ prometheus.scrape "pods" {
 
   scrape_interval = "{{ .Values.global.telemetry.metrics.scrape_interval }}"
   scrape_timeout = "{{ .Values.global.telemetry.metrics.scrape_timeout }}"
-  enable_protobuf_negotiation = {{ .Values.global.telemetry.metrics.nativeHistograms | default false }}
+  enable_protobuf_negotiation = {{ .Values.global.telemetry.metrics.native_histograms | default false }}
 }
 
 // These are metric_relabel_configs while discovery.relabel are relabel_configs.
@@ -302,7 +302,7 @@ prometheus.scrape "cadvisor" {
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   scrape_interval   = "{{ .Values.global.telemetry.metrics.scrape_interval }}"
   scrape_timeout    = "{{ .Values.global.telemetry.metrics.scrape_timeout }}"
-  enable_protobuf_negotiation = {{ .Values.global.telemetry.metrics.nativeHistograms | default false }}
+  enable_protobuf_negotiation = {{ .Values.global.telemetry.metrics.native_histograms | default false }}
 }
 
 prometheus.relabel "cadvisor" {
@@ -348,7 +348,7 @@ prometheus.relabel "cadvisor" {
 
 prometheus.remote_write "default" {
   endpoint {
-    send_native_histograms = {{ .Values.global.telemetry.metrics.nativeHistograms | default false }}
+    send_native_histograms = {{ .Values.global.telemetry.metrics.native_histograms | default false }}
     url ="http://{{ include "prometheus.server.fullname" .Subcharts.prometheus }}.{{ .Release.Namespace }}.{{ .Values.global.zone }}/api/v1/write"
 
     // drop instance label which unnecessarily adds new series when pods are restarted, since pod IPs are dynamically assigned
@@ -399,7 +399,7 @@ prometheus.scrape "coder_metrics" {
 
   forward_to = [prometheus.remote_write.default.receiver]
   scrape_interval = "{{ .scrapeInterval }}"
-  enable_protobuf_negotiation = {{ .Values.global.telemetry.metrics.nativeHistograms | default false }}
+  enable_protobuf_negotiation = {{ .Values.global.telemetry.metrics.native_histograms | default false }}
 }
 {{- end }}
 {{- end }}

--- a/coder-observability/values.yaml
+++ b/coder-observability/values.yaml
@@ -113,8 +113,8 @@ global:
       scrape_interval: 15s
       # global.telemetry.metrics.scrape_timeout -- how long a request will be allowed to wait before being canceled
       scrape_timeout: 12s
-      # global.telemetry.metrics.nativeHistograms -- enable Prometheus native histograms or default to classic histograms
-      nativeHistograms: false
+      # global.telemetry.metrics.native_histograms -- enable Prometheus native histograms or default to classic histograms
+      native_histograms: false
     profiling:
       # global.telemetry.profiling.scrape_interval -- how often the collector will scrape pprof endpoints
       scrape_interval: 60s


### PR DESCRIPTION
Rename `global.telemetry.metrics.nativeHistograms` to `global.telemetry.metrics.native_histograms` for consistency with other flags.

Follow-up: https://github.com/coder/observability/pull/50