### PR TITLE
Revert "chore: explicit scrape duration to be less than the interval (#49)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,14 +328,13 @@ values which are defined [here](https://github.com/grafana/helm-charts/tree/main
 | global.externalZone | string | `"svc.cluster.local"` |  |
 | global.postgres | object | `{"alerts":{"groups":{"Basic":{"delay":"1m","enabled":true},"Connections":{"delay":"5m","enabled":true,"thresholds":{"critical":0.9,"notify":0.5,"warning":0.8}},"Notifications":{"delay":"15m","enabled":true,"thresholds":{"critical":0.9,"notify":0.5,"warning":0.8}}}},"database":"coder","exporter":{"image":"quay.io/prometheuscommunity/postgres-exporter"},"hostname":"localhost","mountSecret":"secret-postgres","password":null,"port":5432,"sslmode":"disable","sslrootcert":null,"username":"coder","volumeMounts":[],"volumes":[]}` | postgres connection information NOTE: these settings are global so we can parameterise some values which get rendered by subcharts |
 | global.postgres.alerts | object | `{"groups":{"Basic":{"delay":"1m","enabled":true},"Connections":{"delay":"5m","enabled":true,"thresholds":{"critical":0.9,"notify":0.5,"warning":0.8}},"Notifications":{"delay":"15m","enabled":true,"thresholds":{"critical":0.9,"notify":0.5,"warning":0.8}}}}` | alerts for postgres |
-| global.telemetry | object | `{"metrics":{"native_histograms":false,"scrape_interval":"15s","scrape_timeout":"12s"},"profiling":{"delta_profiling_duration":"30s","scrape_interval":"60s","scrape_timeout":"70s"}}` | control telemetry collection |
+| global.telemetry | object | `{"metrics":{"native_histograms":false,"scrape_interval":"15s","scrape_timeout":"12s"},"profiling":{"scrape_interval":"60s","scrape_timeout":"70s"}}` | control telemetry collection |
 | global.telemetry.metrics | object | `{"native_histograms":false,"scrape_interval":"15s","scrape_timeout":"12s"}` | control metric collection |
 | global.telemetry.metrics.native_histograms | bool | `false` | enable Prometheus native histograms or default to classic histograms |
 | global.telemetry.metrics.scrape_interval | string | `"15s"` | how often the collector will scrape discovered pods |
 | global.telemetry.metrics.scrape_timeout | string | `"12s"` | how long a request will be allowed to wait before being canceled |
-| global.telemetry.profiling.delta_profiling_duration | string | `"30s"` | duration of each pprof profiling capture, must be less than scrape_interval |
 | global.telemetry.profiling.scrape_interval | string | `"60s"` | how often the collector will scrape pprof endpoints |
-| global.telemetry.profiling.scrape_timeout | string | `"70s"` | how long a request will be allowed to wait before being canceled |
+| global.telemetry.profiling.scrape_timeout | string | `"70s"` | how long a request will be allowed to wait before being canceled, must be larger than scrape_interval |
 | global.zone | string | `"svc"` |  |
 | grafana-agent.agent.clustering.enabled | bool | `true` |  |
 | grafana-agent.agent.configMap.create | bool | `false` |  |

--- a/coder-observability/templates/_collector-config.tpl
+++ b/coder-observability/templates/_collector-config.tpl
@@ -210,7 +210,6 @@ pyroscope.scrape "pods" {
 
   scrape_interval = "{{ .Values.global.telemetry.profiling.scrape_interval }}"
   scrape_timeout = "{{ .Values.global.telemetry.profiling.scrape_timeout }}"
-  delta_profiling_duration = "{{ .Values.global.telemetry.profiling.delta_profiling_duration }}"
 
   clustering {
     enabled = true

--- a/coder-observability/values.yaml
+++ b/coder-observability/values.yaml
@@ -118,10 +118,8 @@ global:
     profiling:
       # global.telemetry.profiling.scrape_interval -- how often the collector will scrape pprof endpoints
       scrape_interval: 60s
-      # global.telemetry.profiling.scrape_timeout -- how long a request will be allowed to wait before being canceled
+      # global.telemetry.profiling.scrape_timeout -- how long a request will be allowed to wait before being canceled, must be larger than scrape_interval
       scrape_timeout: 70s
-      # global.telemetry.profiling.delta_profiling_duration -- duration of each pprof profiling capture, must be less than scrape_interval
-      delta_profiling_duration: 30s
 
   # global.postgres -- postgres connection information
   # NOTE: these settings are global so we can parameterise some values which get rendered by subcharts


### PR DESCRIPTION
This reverts commit f60876c02468e2779f264dc0e312e9f351b32b54.

See https://github.com/coder/dogfood/pull/168#issuecomment-3222788280