### PR TITLE
feat: add Makefile rule to sync chart version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,6 +13,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for fetch git tags step
+
+      # Ensure git tags are available for version scripts
+      - name: Fetch git tags
+        run: git fetch --tags --force
 
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,26 @@ lint/helm/prometheus-rules:
 
 .PHONY: lint/helm/prometheus-rules
 
+# Set coder-observability/Chart.yaml version to the latest stable git tag
+# TODO: auto-update chart version in Chart.yaml when a new release is published
+chart/version-sync:
+	version=$(shell ./scripts/version.sh -s) && \
+	if [ -z "$$version" ]; then \
+		echo "No git tag found. Cannot set Chart.yaml version" >&2; \
+		exit 1; \
+	fi; \
+	yq -i e ".version = \"$$version\"" coder-observability/Chart.yaml
+.PHONY: chart/version-sync
+
 # Usage: publish-patch, publish-minor, publish-major
 # Publishing is handled by GitHub Actions, triggered by tag creation.
 publish-%:
 	version=$(shell ./scripts/version.sh --bump $*) && \
-	git tag --sign "$$version"  -m "Release: $$version" && \
+	git tag --sign "$$version" -m "Release: $$version" && \
 	git push origin tag "$$version"
 
-readme:
+# TODO: auto-update chart version in README files when a new release is published
+readme: chart/version-sync
 	go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
 	helm-docs --output-file ../README.md \
 		--values-file=values.yaml --chart-search-root=coder-observability --template-files=../README.gotmpl

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,4 +1,29 @@
 # Publishing the Coder Observability Chart
 
-- make desired changes
-- run `make publish-{major|minor|patch}` which creates & pushes a new tag, which kicks off a GH Action to publish the chart
+This repo supports both official (stable) releases and release candidates (RCs).
+
+## Official release (stable)
+
+Use this when you’re ready to publish a new release.
+
+1) Make desired changes and ensure CI is green
+2) Cut and push a new tag:
+    - Patch: `make publish-patch`
+    - Minor: `make publish-minor`
+    - Major: `make publish-major`
+
+This creates and pushes a new stable tag (e.g., 0.4.1), which kicks off a GitHub Action to package and publish the chart.
+
+## Release candidate (RC)
+
+To create a new RC version:
+
+```shell
+VERSION=v0.4.0-rc.1
+git tag "$VERSION" -m "Release: $VERSION"
+git push origin tag "$VERSION"
+```
+
+## Helm repo
+
+Use Artifact Hub to browse/search releases: https://artifacthub.io/packages/helm/coder-observability/coder-observability

--- a/README.gotmpl
+++ b/README.gotmpl
@@ -20,11 +20,9 @@ Logs will be scraped from all pods in the Kubernetes cluster.
 
 ## Installation
 
-<!-- TODO: auto-update version here from publish script -->
-
 ```bash
 helm repo add coder-observability https://helm.coder.com/observability
-helm upgrade --install coder-observability coder-observability/coder-observability --version 0.1.1 --namespace coder-observability --create-namespace
+helm upgrade --install coder-observability coder-observability/coder-observability --version {{ template "chart.version" . }} --namespace coder-observability --create-namespace
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -20,11 +20,9 @@ Logs will be scraped from all pods in the Kubernetes cluster.
 
 ## Installation
 
-<!-- TODO: auto-update version here from publish script -->
-
 ```bash
 helm repo add coder-observability https://helm.coder.com/observability
-helm upgrade --install coder-observability coder-observability/coder-observability --version 0.1.1 --namespace coder-observability --create-namespace
+helm upgrade --install coder-observability coder-observability/coder-observability --version 0.3.5 --namespace coder-observability --create-namespace
 ```
 
 ## Requirements

--- a/coder-observability/Chart.yaml
+++ b/coder-observability/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v2
 name: coder-observability
 description: Gain insights into your Coder deployment
-
 type: application
-version: 0.1.0
+version: 0.3.5
 dependencies:
   - name: pyroscope
     condition: pyroscope.enabled


### PR DESCRIPTION
## Description

This PR introduces a Makefile rule to automatically update the Helm chart version in `Chart.yaml` and the version reference in README to the latest stable release.

## Changes

* Updated `scripts/version.sh` with `-s` flag to get the latest stable versions (excluding RC).
* Added `chart/version-sync` Makefile rule for syncing chart version across `Chart.yaml` and `README` file.
* Updated `PUBLISH.md` with instructions for creating both normal and RC releases.
* Updates lint job to fetch git tags required for `make lint`