### PR TITLE
fix: use creatordate to pick latest tag instead of version sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Logs will be scraped from all pods in the Kubernetes cluster.
 
 ```bash
 helm repo add coder-observability https://helm.coder.com/observability
-helm upgrade --install coder-observability coder-observability/coder-observability --version 0.3.5 --namespace coder-observability --create-namespace
+helm upgrade --install coder-observability coder-observability/coder-observability --version 0.4.0 --namespace coder-observability --create-namespace
 ```
 
 ## Requirements

--- a/coder-observability/Chart.yaml
+++ b/coder-observability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: coder-observability
 description: Gain insights into your Coder deployment
 type: application
-version: 0.3.5
+version: 0.4.0
 dependencies:
   - name: pyroscope
     condition: pyroscope.enabled

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 remote_url=$(git remote get-url origin)
 # Newest tag by semantic version (may include prerelease like -rc/-beta/-alpha)
-current_version="$(git tag -l | sort --version-sort | tail -n1)"
+current_version="$(git tag --list --sort=-creatordate | head -n1)"
 # Newest stable version tag (strict X.Y.Z; excludes prereleases)
 stable_version="$(git tag -l | sort --version-sort | grep -E '^(v)?[0-9]+\.[0-9]+\.[0-9]+$' | tail -n1)"
 


### PR DESCRIPTION
Fixes the `version.sh` script to determine the latest version by creation date instead of semantic sorting.

The [publish.sh](https://github.com/coder/observability/blob/main/scripts/publish.sh#L4) script relies on this version to publish to the Helm repo.
Previously, semantic sorting caused release candidates (e.g. `0.4.0-rc.6`) to be considered newer than the final stable release (`0.4.0`).
With this change, stable versions are correctly treated as the latest release.