### PR TITLE
fix: properly determine running workspaces count

### DIFF
--- a/coder-observability/templates/dashboards/_dashboards_status.json.tpl
+++ b/coder-observability/templates/dashboards/_dashboards_status.json.tpl
@@ -404,7 +404,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(kube_pod_status_ready{condition=\"true\", {{ include "workspaces-selector" . -}}} == 1)\nor\ncount(coderd_api_workspace_latest_build{status=\"running\"})\nor\nvector(0)",
+          "expr": "count(kube_pod_status_ready{condition=\"true\", {{ include "workspaces-selector" . -}}} == 1)\nor\nsum(max by (workspace_owner, template_name, template_version) (coderd_workspace_latest_build_status{status=\"succeeded\", workspace_transition=\"start\"}))\nor\nvector(0)",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,

--- a/compiled/resources.yaml
+++ b/compiled/resources.yaml
@@ -5401,7 +5401,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "count(kube_pod_status_ready{condition=\"true\", namespace=`coder-workspaces`} == 1)\nor\ncount(coderd_api_workspace_latest_build{status=\"running\"})\nor\nvector(0)",
+              "expr": "count(kube_pod_status_ready{condition=\"true\", namespace=`coder-workspaces`} == 1)\nor\nsum(max by (workspace_owner, template_name, template_version) (coderd_workspace_latest_build_status{status=\"succeeded\", workspace_transition=\"start\"}))\nor\nvector(0)",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,


### PR DESCRIPTION
Part of the previous query didn't make sense and was completely wrong (though it is admittedly confusing). Here's part of the DB query for retrieving running workspaces:

```
-- Special case where the provisioner status and workspace status
-- differ. A workspace is "running" if the job is "succeeded" and
-- the transition is "start". This is because a workspace starts
-- running when a job is complete.
WHEN $4 = 'running' THEN
    latest_build.job_status = 'succeeded'::provisioner_job_status AND
    latest_build.transition = 'start'::workspace_transition
```

This new promql query follows this logic, but also uses a max by to handle duplicate metrics from multiple coder replicas:
```diff
 count(kube_pod_status_ready{condition="true", namespace=`coder-workspaces`} == 1)
 or
-count(coderd_api_workspace_latest_build{status="running"})
+sum(max by (workspace_owner, template_name, template_version) (coderd_workspace_latest_build_status{status="succeeded", workspace_transition="start"}))
 or
 vector(0)
```


 Tested on dogfood and on my scaletest cluster.