### PR TITLE
fix: sort agent boundaries request tables by time

### DIFF
--- a/coder-observability/templates/dashboards/_dashboards_boundary.json.tpl
+++ b/coder-observability/templates/dashboards/_dashboards_boundary.json.tpl
@@ -569,6 +569,18 @@
               "workspace_name": "Workspace Name"
             }
           }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Time"
+              }
+            ]
+          }
         }
       ],
       "type": "table"
@@ -753,6 +765,18 @@
               "time": "Time",
               "workspace_name": "Workspace Name"
             }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Time"
+              }
+            ]
           }
         }
       ],

--- a/coder-observability/templates/dashboards/_dashboards_boundary.json.tpl
+++ b/coder-observability/templates/dashboards/_dashboards_boundary.json.tpl
@@ -520,12 +520,6 @@
       "title": "Most recent allowed requests",
       "transformations": [
         {
-          "id": "limit",
-          "options": {
-            "limitField": "10"
-          }
-        },
-        {
           "id": "extractFields",
           "options": {
             "delimiter": "|",
@@ -580,6 +574,12 @@
                 "field": "Time"
               }
             ]
+          }
+        },
+        {
+          "id": "limit",
+          "options": {
+            "limitField": "10"
           }
         }
       ],
@@ -717,12 +717,6 @@
       "title": "Most recent denied requests",
       "transformations": [
         {
-          "id": "limit",
-          "options": {
-            "limitField": "10"
-          }
-        },
-        {
           "id": "extractFields",
           "options": {
             "delimiter": "|",
@@ -777,6 +771,12 @@
                 "field": "Time"
               }
             ]
+          }
+        },
+        {
+          "id": "limit",
+          "options": {
+            "limitField": "10"
           }
         }
       ],

--- a/compiled/resources.yaml
+++ b/compiled/resources.yaml
@@ -1606,6 +1606,18 @@ data:
                   "workspace_name": "Workspace Name"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "Time"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1790,6 +1802,18 @@ data:
                   "time": "Time",
                   "workspace_name": "Workspace Name"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "Time"
+                  }
+                ]
               }
             }
           ],

--- a/compiled/resources.yaml
+++ b/compiled/resources.yaml
@@ -1557,12 +1557,6 @@ data:
           "title": "Most recent allowed requests",
           "transformations": [
             {
-              "id": "limit",
-              "options": {
-                "limitField": "10"
-              }
-            },
-            {
               "id": "extractFields",
               "options": {
                 "delimiter": "|",
@@ -1617,6 +1611,12 @@ data:
                     "field": "Time"
                   }
                 ]
+              }
+            },
+            {
+              "id": "limit",
+              "options": {
+                "limitField": "10"
               }
             }
           ],
@@ -1754,12 +1754,6 @@ data:
           "title": "Most recent denied requests",
           "transformations": [
             {
-              "id": "limit",
-              "options": {
-                "limitField": "10"
-              }
-            },
-            {
               "id": "extractFields",
               "options": {
                 "delimiter": "|",
@@ -1814,6 +1808,12 @@ data:
                     "field": "Time"
                   }
                 ]
+              }
+            },
+            {
+              "id": "limit",
+              "options": {
+                "limitField": "10"
               }
             }
           ],


### PR DESCRIPTION
Add sortBy transformation to the "Most recent allowed requests" and "Most recent denied requests" tables so they display with the most recent timestamp at the top. These timestamps represent when boundary audited an HTTP request in a workspace, whereas the order was previously determined by when the log was emitted in coderd logs.

Found while testing v.0.7.0-rc1 in dogfood
<img width="1701" height="797" alt="Screenshot 2026-01-28 at 12 56 27 PM" src="https://github.com/user-attachments/assets/e6fdaa1d-a802-4097-8db0-fe029ebc227a" />

Relates to https://github.com/coder/observability/issues/76