### PR TITLE
fix: preserve unknown status when metrics are missing

### DIFF
--- a/coder-observability/templates/dashboards/_dashboards_status.json.tpl
+++ b/coder-observability/templates/dashboards/_dashboards_status.json.tpl
@@ -692,7 +692,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "min(pg_up) or vector(0)",
+          "expr": "min(pg_up)",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -822,7 +822,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "min(up{job=\"{{- include "prometheus-job" . -}}\"}) or vector(0)",
+          "expr": "min(up{job=\"{{- include "prometheus-job" . -}}\"})",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -939,7 +939,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "min(up{job=\"{{- include "loki-job" . -}}/write\"}) or vector(0)",
+          "expr": "min(up{job=\"{{- include "loki-job" . -}}/write\"})",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -1056,7 +1056,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "min(up{job=\"{{- include "loki-job" . -}}/read\"}) or vector(0)",
+          "expr": "min(up{job=\"{{- include "loki-job" . -}}/read\"})",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -1173,7 +1173,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "min(up{job=\"{{- include "loki-job" . -}}/backend\", container=\"loki\"}) or vector(0)",
+          "expr": "min(up{job=\"{{- include "loki-job" . -}}/backend\", container=\"loki\"})",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -1290,7 +1290,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "min(up{job=\"{{- include "loki-job" . -}}/canary\"}) or vector(0)",
+          "expr": "min(up{job=\"{{- include "loki-job" . -}}/canary\"})",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -1407,7 +1407,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "min(up{job=\"{{- include "grafana-agent-job" . -}}\"}) or vector(0)",
+          "expr": "min(up{job=\"{{- include "grafana-agent-job" . -}}\"})",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -1641,7 +1641,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "min(loki_runtime_config_last_reload_successful) or vector(0)",
+          "expr": "min(loki_runtime_config_last_reload_successful)",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
@@ -1759,7 +1759,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "min(agent_config_last_load_successful{job=\"{{- include "grafana-agent-job" . -}}\"}) or vector(0)",
+          "expr": "min(agent_config_last_load_successful{job=\"{{- include "grafana-agent-job" . -}}\"})",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,

--- a/compiled/resources.yaml
+++ b/compiled/resources.yaml
@@ -6582,7 +6582,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "min(pg_up) or vector(0)",
+              "expr": "min(pg_up)",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -6712,7 +6712,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "min(up{job=\"coder-observability/prometheus/server\"}) or vector(0)",
+              "expr": "min(up{job=\"coder-observability/prometheus/server\"})",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -6829,7 +6829,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "min(up{job=\"coder-observability/loki/write\"}) or vector(0)",
+              "expr": "min(up{job=\"coder-observability/loki/write\"})",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -6946,7 +6946,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "min(up{job=\"coder-observability/loki/read\"}) or vector(0)",
+              "expr": "min(up{job=\"coder-observability/loki/read\"})",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7063,7 +7063,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "min(up{job=\"coder-observability/loki/backend\", container=\"loki\"}) or vector(0)",
+              "expr": "min(up{job=\"coder-observability/loki/backend\", container=\"loki\"})",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7180,7 +7180,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "min(up{job=\"coder-observability/loki/canary\"}) or vector(0)",
+              "expr": "min(up{job=\"coder-observability/loki/canary\"})",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7297,7 +7297,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "min(up{job=\"coder-observability/grafana-agent/grafana-agent\"}) or vector(0)",
+              "expr": "min(up{job=\"coder-observability/grafana-agent/grafana-agent\"})",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7531,7 +7531,7 @@ data:
                 "uid": "prometheus"
               },
               "editorMode": "code",
-              "expr": "min(loki_runtime_config_last_reload_successful) or vector(0)",
+              "expr": "min(loki_runtime_config_last_reload_successful)",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -7649,7 +7649,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "min(agent_config_last_load_successful{job=\"coder-observability/grafana-agent/grafana-agent\"}) or vector(0)",
+              "expr": "min(agent_config_last_load_successful{job=\"coder-observability/grafana-agent/grafana-agent\"})",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,


### PR DESCRIPTION
## Summary

- let missing status metrics reach the dashboards' existing `Unknown` value mapping instead of synthesizing a zero/`Down` result
- apply the behavior consistently to the nine service and configuration status panels
- update the compiled chart resources

## Validation

- `scripts/compile.sh` with Helm v3.17.3 and yq v4.42.1 in an LF checkout
- `helm lint --strict --set coder.image.tag=v0.7.2 coder-observability/`
- rendered `coder-status.json` parsing and assertions across all nine affected panels
- `git diff --check`

Fixes #24